### PR TITLE
update typings a bit

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@
  *
  * The support for having multiple tsconfig files in vscode is non-existent.
  */
+
 cy.mount("");
 
 function App() {

--- a/tsconfig.cypress.component.json
+++ b/tsconfig.cypress.component.json
@@ -1,6 +1,6 @@
 {
   "extends": ["./tsconfig.app.json"],
-  "include": ["src", "cypress", "cypress.config.ts"],
+  "include": ["cypress", "cypress.config.ts"],
   "exclude": [],
   "compilerOptions": {}
 }


### PR DESCRIPTION
I don't know why but as you can see bottom corner wrong tsconfig is loaded by default, so you need to be more strict about what to `include` and `exclude` in all of the tsconfig files so they will not overlap
<img width="1720" alt="image" src="https://github.com/WojciechMatuszewski/multiple-tsconfig-cypress/assets/22987951/0204c550-dc5e-4ef2-8ba8-bd6bed87cf0d"> 
Also, you need to exclude global typings of cypress to not be available in the app code 
So what it looks like after changes
<img width="1728" alt="Screenshot 2023-10-01 at 08 53 13" src="https://github.com/WojciechMatuszewski/multiple-tsconfig-cypress/assets/22987951/d9a3db9c-e782-4906-9351-bbfbc241ad9b">
